### PR TITLE
Dropping `flake8` to replace `ruff` linter check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-ignore =
-    # line break before binary operator
-    W503,
-    # line length too long
-    E501,
-    # Quotes (temporary)
-    Q0,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,6 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          ["flake8-black==0.3.6", "flake8-isort==6.1.1", "flake8-quotes==3.3.2"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Dropping `flake8` to replace `ruff` linter check.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
