### PR TITLE
Dropping Makefile support to use the nox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-doctest-modules:
-	@echo "Running module doctesting"
-	pytest -v --doctest-modules src/skgmsh


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Dropping Makefile support to use the nox.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
