### PR TITLE
Add pip group update settings to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    groups:
+      pip:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
The setting to update multiple versions together in one PR has been added to `dependabot`! This frees you from a large number of `dependabot` PRs.
[Grouped version updates for Dependabot public beta.
](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)
Inspired by #566.

<!-- Tell us all about your new feature, improvement, or bug fix -->
### Details

- [Grouped version updates for Dependabot public beta.
](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)
- https://github.com/dependabot/dependabot-core/issues/1190
---
