### PR TITLE
Ignore dependabot and pre-commit-ci PR for release

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,3 +16,8 @@ jobs:
           sync-labels: true
           configuration-path: .github/labeler.yml
           dot: true
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' ||  github.actor == 'pre-commit-ci[bot]'
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: ignore-for-release


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
PR of @dependabot and @pre-commit-ci is noisy to read the release notes. Let's add [ignore-for-release](https://github.com/pyvista/scikit-gmsh/labels/ignore-for-release) to them and remove it from the release note.
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None