### PR TITLE
Forces all from imports to appear on their own line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ ignore = [
   "ISC001"
 ]
 
+[tool.ruff.lint.isort]
+force-single-line = true
+
 [tool.ruff.lint.per-file-ignores]
 "docs/**" = ["INP001"]
 "tests/**" = ["INP001", "S101"]


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
> [!NOTE]
> https://docs.astral.sh/ruff/settings/#lint_isort_force-single-line

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None
<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
