### PR TITLE
Update open-pull-requests-limit in dependabot.yml to 100

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     insecure-external-code-execution: allow
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 100
     labels:
       - "maintenance"
       - "dependencies"
@@ -16,6 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 100
     labels:
       - "maintenance"
       - "dependencies"


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
By default, dependabot's `open-pull-requests-limit` is set to 5. This is too small for this project. This PR set open-pull-requests-limit to 100 to ensure that all dependencies are updated.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit
