### PR TITLE
Dropping black and use ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,6 @@ ci:
   autofix_prs: true
   autoupdate_schedule: weekly
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.18.0
     hooks:
@@ -83,6 +79,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
   - repo: https://github.com/scientific-python/cookie
     rev: 2024.04.23
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,8 +202,6 @@ section](#creating-a-new-pull-request).
 
 #### Coding Style
 
-[![Code style:
-black](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge)](https://github.com/psf/black)
 [![Imports:
 isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=for-the-badge&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json&style=for-the-badge)](https://github.com/astral-sh/ruff)
@@ -214,7 +212,7 @@ We adhere to [PEP 8](https://www.python.org/dev/peps/pep-0008/) wherever
 possible, except that line widths are permitted to go beyond 79
 characters to a max of 99 characters for code. This should tend to be
 the exception rather than the norm. A uniform code style is enforced by
-[black](https://github.com/psf/black) to prevent energy wasted on style
+[Ruff](https://github.com/astral-sh/ruff) to prevent energy wasted on style
 disagreements.
 
 As for docstrings, scikit-gmsh follows the `numpydoc` style for its
@@ -555,7 +553,7 @@ style requirements:
 
     $ pre-commit install
     $ git commit -m "added my cool feature"
-    black....................................................................Passed
+    ruff.....................................................................Passed
     isort....................................................................Passed
     flake8...................................................................Passed
     codespell................................................................Passed

--- a/src/skgmsh/__init__.py
+++ b/src/skgmsh/__init__.py
@@ -43,9 +43,7 @@ class Report(scooby.Report):  # type: ignore[misc]
 
     """
 
-    def __init__(
-        self: Report, ncol: int = 3, text_width: int = 80
-    ) -> None:  # numpydoc ignore=PR01
+    def __init__(self: Report, ncol: int = 3, text_width: int = 80) -> None:  # numpydoc ignore=PR01
         """Generate a :class:`scooby.Report` instance."""
         # mandatory packages
         core: list[str] = [
@@ -146,9 +144,7 @@ def delaunay_3d(
         gmsh.model.geo.add_line(face[1] + 1, face[2] + 1, i * 4 + 1)
         gmsh.model.geo.add_line(face[2] + 1, face[3] + 1, i * 4 + 2)
         gmsh.model.geo.add_line(face[3] + 1, face[0] + 1, i * 4 + 3)
-        gmsh.model.geo.add_curve_loop(
-            [i * 4 + 0, i * 4 + 1, i * 4 + 2, i * 4 + 3], i + 1
-        )
+        gmsh.model.geo.add_curve_loop([i * 4 + 0, i * 4 + 1, i * 4 + 2, i * 4 + 3], i + 1)
         gmsh.model.geo.add_plane_surface([i + 1], i + 1)
         gmsh.model.geo.remove_all_duplicates()
         gmsh.model.geo.synchronize()
@@ -229,10 +225,8 @@ def frontal_delaunay_2d(
         target_sizes = [target_sizes] * edge_source.number_of_points
 
     embedded_points = []
-    for i, (target_size, point) in enumerate(zip(target_sizes, points)):
-        id_ = i + 1
-        gmsh.model.geo.add_point(point[0], point[1], point[2], target_size, id_)
-        embedded_points.append(id_)
+    for target_size, point in zip(target_sizes, points):
+        embedded_points.append(gmsh.model.geo.add_point(point[0], point[1], point[2], target_size))
 
     for i in range(lines[0] - 1):
         id_ = i + 1

--- a/tests/test_skgmsh.py
+++ b/tests/test_skgmsh.py
@@ -45,9 +45,7 @@ def test_frontal_delaunay_2d_recombine() -> None:
 
 @pytest.mark.parametrize("edge_source", EDGE_SOURCES)
 @pytest.mark.parametrize("target_sizes", [2.0, [1.0, 2.0, 3.0, 4.0]])
-def test_frontal_delaunay_2d(
-    edge_source: pv.Polygon, target_sizes: float | Sequence[float]
-) -> None:
+def test_frontal_delaunay_2d(edge_source: pv.Polygon, target_sizes: float | Sequence[float]) -> None:
     """Frontal-Delaunay 2D mesh algorithm test code."""
     mesh = sg.frontal_delaunay_2d(edge_source, target_sizes=target_sizes)
     assert mesh.number_of_points > edge_source.number_of_points
@@ -57,9 +55,7 @@ def test_frontal_delaunay_2d(
     # https://github.com/pyvista/scikit-gmsh/pull/125
 
 
-@pytest.mark.parametrize(
-    "target_sizes", [0.5, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]]
-)
+@pytest.mark.parametrize("target_sizes", [0.5, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]])
 def test_delaunay_3d(target_sizes: float | Sequence[float]) -> None:
     """Delaunay 3D mesh algorithm test code."""
     edge_source = pv.Cube()


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The Ruff formatter is an extremely fast Python code formatter designed as a drop-in replacement for [Black](https://pypi.org/project/black/), available as part of the ruff CLI via ruff format.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- https://docs.astral.sh/ruff/settings/#format_docstring-code-format
