### PR TITLE
Dropping isort and move to lint.isort rule in ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,6 @@ repos:
     rev: 0.29.1
     hooks:
       - id: check-github-workflows
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -554,7 +554,6 @@ style requirements:
     $ pre-commit install
     $ git commit -m "added my cool feature"
     black....................................................................Passed
-    flake8...................................................................Passed
     codespell................................................................Passed
 
 The actual installation of the environment happens before the first

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,8 +204,6 @@ section](#creating-a-new-pull-request).
 
 [![Code style:
 black](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge)](https://github.com/psf/black)
-[![Imports:
-isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=for-the-badge&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json&style=for-the-badge)](https://github.com/astral-sh/ruff)
 [![code style:
 prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=for-the-badge)](https://github.com/prettier/prettier)
@@ -556,7 +554,6 @@ style requirements:
     $ pre-commit install
     $ git commit -m "added my cool feature"
     black....................................................................Passed
-    isort....................................................................Passed
     flake8...................................................................Passed
     codespell................................................................Passed
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,8 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 from __future__ import annotations
 
 import datetime
-import os
 from importlib.metadata import version as get_version
+import os
 from pathlib import Path
 
 # -- Project information -----------------------------------------------------

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Automation using nox."""
+from __future__ import annotations
 
 import nox
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Automation using nox."""
+
 from __future__ import annotations
 
 import nox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,11 @@ force-single-line = true
 [tool.setuptools.dynamic]
 version = {attr = 'skgmsh.__version__'}
 readme = {file = "README.md", content-type = "text/markdown"}
+
+[tool.ruff.lint.isort]
+# Sort by name, don't cluster "from" vs "import"
+force-sort-within-sections = true
+# Combines "as" imports on the same line
+combine-as-imports = true
+required-imports = ["from __future__ import annotations"]
+force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,6 @@ force-single-line = true
 "docs/**" = ["INP001"]
 "tests/**" = ["INP001", "S101"]
 
-[tool.setuptools.dynamic]
-version = {attr = 'skgmsh.__version__'}
-readme = {file = "README.md", content-type = "text/markdown"}
-
 [tool.ruff.lint.isort]
 # Sort by name, don't cluster "from" vs "import"
 force-sort-within-sections = true
@@ -84,3 +80,8 @@ force-sort-within-sections = true
 combine-as-imports = true
 required-imports = ["from __future__ import annotations"]
 force-single-line = true
+
+[tool.setuptools.dynamic]
+version = {attr = 'skgmsh.__version__'}
+readme = {file = "README.md", content-type = "text/markdown"}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,19 +67,16 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-force-single-line = true
-
-[tool.ruff.lint.per-file-ignores]
-"docs/**" = ["INP001"]
-"tests/**" = ["INP001", "S101"]
-
-[tool.ruff.lint.isort]
 # Sort by name, don't cluster "from" vs "import"
 force-sort-within-sections = true
 # Combines "as" imports on the same line
 combine-as-imports = true
 required-imports = ["from __future__ import annotations"]
 force-single-line = true
+
+[tool.ruff.lint.per-file-ignores]
+"docs/**" = ["INP001"]
+"tests/**" = ["INP001", "S101"]
 
 [tool.setuptools.dynamic]
 version = {attr = 'skgmsh.__version__'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,4 +84,3 @@ force-single-line = true
 [tool.setuptools.dynamic]
 version = {attr = 'skgmsh.__version__'}
 readme = {file = "README.md", content-type = "text/markdown"}
-

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """scikit-gmsh setuptools packaging."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """scikit-gmsh setuptools packaging."""
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/src/skgmsh/__init__.py
+++ b/src/skgmsh/__init__.py
@@ -6,9 +6,9 @@ import datetime
 from typing import TYPE_CHECKING
 
 import gmsh
+from pygmsh.helpers import extract_to_meshio
 import pyvista as pv
 import scooby
-from pygmsh.helpers import extract_to_meshio
 
 if TYPE_CHECKING:
     from collections.abc import Sequence


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Dropping `isort` and moving to `lint.isort` rule in `ruff`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://docs.astral.sh/ruff/rules/#isort-i.
