### PR TITLE
Dropping pyupgrade and move to pyupgrade-up rule in ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,11 +53,6 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json, toml]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
-    hooks:
-      - id: pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.7.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ force-single-line = true
 "docs/**" = ["INP001"]
 "tests/**" = ["INP001", "S101"]
 
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
+
 [tool.setuptools.dynamic]
 version = {attr = 'skgmsh.__version__'}
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Dropping `pyupgrade ` and moving to `pyupgrade-up` rule in `ruff`.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- See https://docs.astral.sh/ruff/rules/#pyupgrade-up.
