### PR TITLE
Fix to push only tags created in the minor release step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -848,7 +848,7 @@ created the following will occur:
 
     ```bash
     git push origin HEAD
-    git push origin --tags
+    git push origin v$(python -c "import scikit-gmsh as sg; print(sg.__version__)")
     ```
 
 1.  Create a list of all changes for the release. It is often helpful to


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Fix to push only tags created in the minor release step.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None