### PR TITLE
Fix timing of `remove_all_duplicates` in `Delaunay3D` class

### DIFF
--- a/src/skgmsh/__init__.py
+++ b/src/skgmsh/__init__.py
@@ -166,9 +166,10 @@ def delaunay_3d(
             curve_tags.append(curve_tag)
         gmsh.model.geo.add_curve_loop(curve_tags, i + 1)
         gmsh.model.geo.add_plane_surface([i + 1], i + 1)
-        gmsh.model.geo.remove_all_duplicates()
-        gmsh.model.geo.synchronize()
         surface_loop.append(i + 1)
+
+    gmsh.model.geo.remove_all_duplicates()
+    gmsh.model.geo.synchronize()
 
     gmsh.model.geo.add_surface_loop(surface_loop, 1)
     gmsh.model.geo.add_volume([1], 1)


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The `gmsh.model.geo.remove_all_duplicates()` function is used to remove duplicates, but it should be called at the appropriate time. Generally, this should be done after defining all geometry and before the final `synchronize().`

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- found in #313