### PR TITLE
Dropping `libgl1-mesa-dev` from packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,5 @@
 libfltk1.3-dev
 libfreetype6-dev
-libgl1-mesa-dev
 libglu1
 libocct-data-exchange-dev
 libocct-foundation-dev


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
Dropping `libgl1-mesa-dev` from packages.txt.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None