### PR TITLE
Add `taplo` pre-commit hook to format and sort `toml` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,12 @@ repos:
     rev: 2024.08.19
     hooks:
       - id: sp-repo-review
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        # See options: https://taplo.tamasfe.dev/configuration/formatter-options.html
+        args: [--option, "reorder_arrays=true"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -90,7 +96,3 @@ repos:
         args: [--branch, main]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
-    hooks:
-      - id: toml-sort-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,20 @@ requires = [
   'pyvista[all]<0.44.2',
   'scooby<0.9.3',
   'setuptools<69.0.4',
-  'shapely<2.0.6'
+  'shapely<2.0.6',
 ]
 build-backend = 'setuptools.build_meta'
 
 [project]
 name = "scikit-gmsh"
-dynamic = [
-  "readme",
-  "version"
-]
+dynamic = ["readme", "version"]
 dependencies = [
   'gmsh<4.12.3',
   'meshio<5.3.6',
   'pygmsh<7.1.18',
   'pyvista[all]<0.44.2',
   'scooby<0.9.3',
-  'shapely<2.0.6'
+  'shapely<2.0.6',
 ]
 requires-python = '>=3.9'
 
@@ -30,12 +27,12 @@ requires-python = '>=3.9'
 test = ['pytest==8.0.0']
 docs = [
   'myst-parser==4.0.0',
-  'sphinx==8.0.2',
   'sphinx-book-theme==1.1.3',
   'sphinx-copybutton==0.5.2',
   'sphinx-design==0.6.1',
   'sphinx-gallery==0.17.1',
-  'sphinx-toolbox==3.8.0'
+  'sphinx-toolbox==3.8.0',
+  'sphinx==8.0.2',
 ]
 
 [tool.mypy]
@@ -53,13 +50,11 @@ version = "0.0.0"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["--showlocals", "--strict-config", "--strict-markers", "-ra"]
 xfail_strict = true
 filterwarnings = ["error", 'ignore::DeprecationWarning']
 log_cli_level = "info"
-testpaths = [
-  "tests"
-]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 150
@@ -69,12 +64,7 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = [
-  "COM812",
-  "D203",
-  "D212",
-  "ISC001"
-]
+ignore = ["COM812", "D203", "D212", "ISC001"]
 
 [tool.ruff.lint.isort]
 # Sort by name, don't cluster "from" vs "import"
@@ -94,5 +84,5 @@ force-single-line = true
 keep-runtime-typing = true
 
 [tool.setuptools.dynamic]
-version = {attr = 'skgmsh.__version__'}
-readme = {file = "README.md", content-type = "text/markdown"}
+version = { attr = 'skgmsh.__version__' }
+readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
ref https://github.com/pyvista/pyvista/pull/6781
<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->

### Details

- None