### PR TITLE
Fix PR update workflow permission errors for forks

### DIFF
--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -10,9 +10,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      repository-projects: read
+      issues: read
     steps:
       - name: Automatically update PR
-        uses: adRise/update-pr-branch@84354a688583b4a3598345e534e7ad49f98e7330
+        uses: adRise/update-pr-branch@v0.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: "main"
@@ -21,3 +23,5 @@ jobs:
           sort: "created"
           direction: "desc"
           require_auto_merge_enabled: true
+          # Skip PRs from forks as GITHUB_TOKEN cannot update fork branches
+          skip_if_head_is_fork: true


### PR DESCRIPTION
## Summary
- Fixes the GitHub Actions workflow error when trying to update PRs from forks
- Adds `skip_if_head_is_fork: true` parameter to avoid permission errors
- Updates action version to stable release tag

## Problem
The workflow was failing with error:
```
HttpError: user doesn't have permission to update head repository
```

This occurs because `GITHUB_TOKEN` cannot push changes to fork repositories.

## Solution
- Added `skip_if_head_is_fork: true` to skip updating PRs that originate from forks
- Updated action version from commit SHA to stable version tag `v0.1.0`
- Added additional permissions for better compatibility

## Test plan
- [ ] Workflow should run without errors on next push to main
- [ ] PRs from the main repository should still be updated
- [ ] PRs from forks should be skipped without causing workflow failure

🤖 Generated with [Claude Code](https://claude.ai/code)