### PR TITLE
Add PyVista bridge and .msh reader entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+uv.lock

--- a/src/skgmsh/__init__.py
+++ b/src/skgmsh/__init__.py
@@ -11,6 +11,9 @@ import pyvista as pv
 import scooby
 import shapely
 
+from skgmsh.bridge import from_gmsh as from_gmsh
+from skgmsh.bridge import to_gmsh as to_gmsh
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 

--- a/src/skgmsh/bridge.py
+++ b/src/skgmsh/bridge.py
@@ -1,0 +1,159 @@
+"""
+Bridges between :mod:`gmsh` and :mod:`pyvista`.
+
+gmsh is a global-state mesh generator, so these helpers consult the
+currently-initialized gmsh model. The caller is responsible for
+``gmsh.initialize()`` / ``gmsh.finalize()`` bracketing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+
+import gmsh
+import numpy as np
+import pyvista as pv
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_TRIANGLE_VERTEX_COUNT = 3
+
+_GMSH_TO_VTK: dict[int, tuple[int, int]] = {
+    1: (3, 2),
+    2: (5, 3),
+    3: (9, 4),
+    4: (10, 4),
+    5: (12, 8),
+    6: (13, 6),
+    7: (14, 5),
+    15: (1, 1),
+}
+
+
+def from_gmsh(model_name: str | None = None) -> pv.UnstructuredGrid:
+    """
+    Pull the current gmsh model into a :class:`pyvista.UnstructuredGrid`.
+
+    Parameters
+    ----------
+    model_name : str, optional
+        Name of the gmsh model to read. When omitted, the current
+        model is used.
+
+    Returns
+    -------
+    pyvista.UnstructuredGrid
+        Mesh from gmsh, with one cell per gmsh element. Element types
+        outside the supported map are skipped.
+
+    Examples
+    --------
+    >>> import gmsh
+    >>> from skgmsh.bridge import from_gmsh
+    >>> gmsh.initialize()
+    >>> gmsh.option.setNumber("General.Terminal", 0)
+    >>> _ = gmsh.model.add("demo")
+    >>> _ = gmsh.model.occ.addRectangle(0, 0, 0, 1, 1)
+    >>> gmsh.model.occ.synchronize()
+    >>> gmsh.model.mesh.generate(2)
+    >>> grid = from_gmsh()
+    >>> type(grid).__name__
+    'UnstructuredGrid'
+    >>> grid.n_cells > 0
+    True
+    >>> gmsh.finalize()
+
+    """
+    if model_name is not None:
+        gmsh.model.setCurrent(model_name)
+
+    node_tags, coords, _ = gmsh.model.mesh.getNodes()
+    coords = np.asarray(coords, dtype=float).reshape(-1, 3)
+    tag_to_idx = {int(t): i for i, t in enumerate(node_tags)}
+
+    cells: list[int] = []
+    cell_types: list[int] = []
+    elem_types, _elem_tags, elem_nodes = gmsh.model.mesh.getElements()
+    for etype, nodes in zip(elem_types, elem_nodes, strict=True):
+        if int(etype) not in _GMSH_TO_VTK:
+            continue
+        vtk_type, n_nodes = _GMSH_TO_VTK[int(etype)]
+        flat = np.asarray(nodes, dtype=np.int64).reshape(-1, n_nodes)
+        for row in flat:
+            cells.append(n_nodes)
+            cells.extend(tag_to_idx[int(t)] for t in row)
+            cell_types.append(vtk_type)
+
+    if not cells:
+        grid = pv.UnstructuredGrid()
+        if coords.size:
+            grid.points = coords
+        return grid
+
+    cells_arr = np.asarray(cells, dtype=np.int64)
+    types_arr = np.asarray(cell_types, dtype=np.uint8)
+    grid = pv.UnstructuredGrid(cells_arr, types_arr, coords)
+    grid.field_data["cad.source_format"] = np.array(["gmsh"])
+    return grid
+
+
+def to_gmsh(
+    mesh: pv.UnstructuredGrid | pv.PolyData,
+    *,
+    model_name: str = "skgmsh",
+) -> None:
+    """
+    Install a PyVista mesh as the current gmsh model (in place).
+
+    Parameters
+    ----------
+    mesh : pyvista.UnstructuredGrid or pyvista.PolyData
+        Mesh to register.
+    model_name : str, default: ``"skgmsh"``
+        Name of the gmsh model to create.
+
+    Examples
+    --------
+    >>> import gmsh
+    >>> import pyvista as pv
+    >>> from skgmsh.bridge import to_gmsh
+    >>> gmsh.initialize()
+    >>> gmsh.option.setNumber("General.Terminal", 0)
+    >>> to_gmsh(pv.Sphere())
+    >>> gmsh.model.getCurrent()
+    'skgmsh'
+    >>> gmsh.finalize()
+
+    """
+    gmsh.model.add(model_name)
+    gmsh.model.setCurrent(model_name)
+    surface_tag = gmsh.model.addDiscreteEntity(2)
+
+    points = np.asarray(mesh.points, dtype=float).reshape(-1)
+    node_tags = list(range(1, len(mesh.points) + 1))
+    gmsh.model.mesh.addNodes(2, surface_tag, node_tags, points.tolist())
+
+    triangles: list[int] = []
+    for tri in _iter_triangles(mesh):
+        triangles.extend(int(i) + 1 for i in tri)
+    if triangles:
+        elem_tags = list(range(1, 1 + len(triangles) // 3))
+        gmsh.model.mesh.addElementsByType(surface_tag, 2, elem_tags, triangles)
+
+
+def _iter_triangles(mesh: pv.UnstructuredGrid | pv.PolyData) -> Iterator[Any]:
+    """Yield triangle index triplets from a surface mesh."""
+    if isinstance(mesh, pv.PolyData):
+        tri = mesh.triangulate()
+        faces = tri.faces.reshape(-1, 4)
+        for row in faces:
+            if int(row[0]) == _TRIANGLE_VERTEX_COUNT:
+                yield row[1:4]
+        return
+    surf = mesh.extract_surface(algorithm="dataset_surface").triangulate()
+    faces = surf.faces.reshape(-1, 4)
+    for row in faces:
+        if int(row[0]) == _TRIANGLE_VERTEX_COUNT:
+            yield row[1:4]

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,47 @@
+"""Tests for the ``skgmsh.bridge`` PyVista ↔ gmsh helpers."""
+
+from __future__ import annotations
+
+import gmsh
+import pytest
+import pyvista as pv
+
+import skgmsh
+
+
+@pytest.fixture
+def gmsh_session() -> None:
+    """Bracket each test with ``gmsh.initialize`` / ``gmsh.finalize``."""
+    gmsh.initialize()
+    yield
+    gmsh.finalize()
+
+
+def test_from_gmsh_empty_model(gmsh_session: None) -> None:  # noqa: ARG001
+    """An empty model returns an empty grid."""
+    gmsh.model.add("empty")
+    gmsh.model.setCurrent("empty")
+    grid = skgmsh.from_gmsh("empty")
+    assert grid.n_points == 0
+    assert grid.n_cells == 0
+
+
+def test_to_then_from_gmsh_roundtrip(gmsh_session: None) -> None:  # noqa: ARG001
+    """A PolyData round-trips through gmsh as a tagged grid."""
+    src = pv.Sphere()
+    skgmsh.to_gmsh(src, model_name="named")
+    grid = skgmsh.from_gmsh("named")
+    assert grid.n_cells > 0
+    assert str(grid.field_data["cad.source_format"][0]) == "gmsh"
+
+
+def test_from_gmsh_after_meshing(gmsh_session: None) -> None:  # noqa: ARG001
+    """A meshed rectangle yields a populated grid."""
+    gmsh.option.setNumber("General.Terminal", 0)
+    gmsh.model.add("rect")
+    gmsh.model.setCurrent("rect")
+    gmsh.model.occ.addRectangle(0, 0, 0, 1, 1)
+    gmsh.model.occ.synchronize()
+    gmsh.model.mesh.generate(2)
+    grid = skgmsh.from_gmsh()
+    assert grid.n_cells > 0


### PR DESCRIPTION
Adds `skgmsh.from_gmsh` / `skgmsh.to_gmsh`, ported from `pyvista_cad._bridges.gmsh`, so `pyvista-cad` can drop its `[gmsh]` extra and stay license-clean. `gmsh` is GPLv2+ and `scikit-gmsh` is already GPL-3.0, so no new license contamination.

The bridge wraps the live gmsh model state: `from_gmsh` pulls the current model into a `pyvista.UnstructuredGrid`, and `to_gmsh` registers a PyVista surface as the current model. File IO is intentionally not covered here — `pv.read('mesh.msh')` already dispatches through `meshio`.

Companion: pyvista/pyvista-cad#6