### PR TITLE
Add multilingual README support for zh-CN, ja, es

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 </h1>
 
 <!-- hy-mt2-i18n:start -->
+
 **English** · [中文](./README_zh-CN.md) · [日本語](./README_ja.md) · [Español](./README_es.md)
 <!-- hy-mt2-i18n:end -->
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
          width="200"></a>
 </h1>
 
+<!-- hy-mt2-i18n:start -->
+**English** · [中文](./README_zh-CN.md) · [日本語](./README_ja.md) · [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
 > Scikit for Gmsh to generate 3D finite element mesh.
 
 [![Status](https://badgen.net/badge/status/alpha/d8624d)](https://badgen.net/badge/status/alpha/d8624d)

--- a/README_es.md
+++ b/README_es.md
@@ -1,4 +1,5 @@
 <!-- hy-mt2-i18n:start -->
+
 [English](./README.md) | [中文](./README_zh-CN.md) | [日本語](./README_ja.md) | **Español**
 <!-- hy-mt2-i18n:end -->
 
@@ -26,7 +27,7 @@ El paquete `scikit-gmsh` ofrece una interfaz sencilla para:
 
 La biblioteca tiene los siguientes objetivos principales:
 
-1. Ofrecer una API intuitiva y orientada a objetos para la creación de mallas, similar a la [clase scipy.spatial.Delaunay](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html).  
+1. Ofrecer una API intuitiva y orientada a objetos para la creación de mallas, similar a la [clase scipy.spatial.Delaunay](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html).
 1. Integrarse perfectamente con otras bibliotecas del [ecosistema Scientific Python](https://scientific-python.org/).
 
 ## Instalación
@@ -57,12 +58,12 @@ Eche un vistazo a las galerías de ejemplos organizadas por tema aquí:
 
 Es posible que esta biblioteca no satisfaga sus necesidades; si es así, considere echar un vistazo a estos otros recursos:
 
-- [meshwell](https://github.com/simbilod/meshwell) - Envoltorio para GMSH con enfoque en la óptica fotónica integrada.  
-- [objectgmsh](https://github.com/nemocrys/objectgmsh) - Modelado orientado a objetos con Gmsh.  
-- [optimesh](https://github.com/meshpro/optimesh) - Optimización y suavizado de mallas.  
-- [pandamesh](https://github.com/Deltares/pandamesh) - Conversión de geodatos a mallas.  
-- [pygalmesh](https://github.com/meshpro/pygalmesh) - Interfaz en Python para las herramientas de malla de CGAL.  
-- [pygmsh](https://github.com/nschloe/pygmsh) - Gmsh para Python.  
+- [meshwell](https://github.com/simbilod/meshwell) - Envoltorio para GMSH con enfoque en la óptica fotónica integrada.
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) - Modelado orientado a objetos con Gmsh.
+- [optimesh](https://github.com/meshpro/optimesh) - Optimización y suavizado de mallas.
+- [pandamesh](https://github.com/Deltares/pandamesh) - Conversión de geodatos a mallas.
+- [pygalmesh](https://github.com/meshpro/pygalmesh) - Interfaz en Python para las herramientas de malla de CGAL.
+- [pygmsh](https://github.com/nschloe/pygmsh) - Gmsh para Python.
 - [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) - Generación de mallas mediante PyVista.
 
 ## Licencia
@@ -73,8 +74,8 @@ Este software se publica bajo la licencia [GPLv3](https://www.gnu.org/licenses/g
 
 ## Contribuciones
 
-Las contribuciones son _muy bienvenidas_.  
-Este proyecto se publica con un [Código de conducta para colaboradores](CODE_OF_CONDUCT.md).  
+Las contribuciones son _muy bienvenidas_.
+Este proyecto se publica con un [Código de conducta para colaboradores](CODE_OF_CONDUCT.md).
 Al participar en este proyecto, queremos que sepa que acepta cumplir con sus términos.
 
 ## Historial de estrellas

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,84 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | [日本語](./README_ja.md) | **Español**
+<!-- hy-mt2-i18n:end -->
+
+<h1 align="center">
+  <a href="https://github.com/pyvista/scikit-gmsh#--------">
+    <img src="https://raw.githubusercontent.com/pyvista/scikit-gmsh/main/docs/_static/logo.svg"
+         alt="scikit-gmsh"
+         width="200"></a>
+</h1>
+
+Scikit para Gmsh, destinado a generar mallas de elementos finitos en 3D.
+
+[![Estado](https://badgen.net/badge/status/alpha/d8624d)](https://badgen.net/badge/status/alpha/d8624d)
+[![Todos los colaboradores](https://img.shields.io/github/all-contributors/pyvista/scikit-gmsh?color=ee8449)](https://scikit-gmsh.readthedocs.io/en/latest/reference/about.html#contributors)
+[![Colaborar](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg)](https://github.com/pyvista/scikit-gmsh/issues)
+[![Estado de la documentación](https://readthedocs.org/projects/scikit-gmsh/badge/?version=latest)](https://scikit-gmsh.readthedocs.io/en/latest/?badge=latest)
+[![Estrellas del repositorio en GitHub](https://img.shields.io/github/stars/pyvista/scikit-gmsh)](https://github.com/pyvista/scikit-gmsh/stargazers)
+[![Licencia: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Covenant de colaboradores](https://img.shields.io/badge/contributor%20covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Scientific Python](https://img.shields.io/badge/SPEC-0-blue.svg)](https://scientific-python.org/specs/spec-0000/)
+
+El paquete `scikit-gmsh` ofrece una interfaz sencilla para:
+
+- [Gmsh](https://pypi.org/project/gmsh/) de Christophe Geuzaine y Jean-François Remacle
+
+La biblioteca tiene los siguientes objetivos principales:
+
+1. Ofrecer una API intuitiva y orientada a objetos para la creación de mallas, similar a la [clase scipy.spatial.Delaunay](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html).  
+1. Integrarse perfectamente con otras bibliotecas del [ecosistema Scientific Python](https://scientific-python.org/).
+
+## Instalación
+
+[![pypi](https://img.shields.io/pypi/v/scikit-gmsh?label=pypi&logo=python&logoColor=white)](https://pypi.org/project/scikit-gmsh/)
+
+```shell
+pip install scikit-gmsh
+```
+
+## Galería
+
+Eche un vistazo a las galerías de ejemplos organizadas por tema aquí:
+
+<p align="center">
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/icosahedron.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_icosahedron_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/polygon_with_hole.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_polygon_with_hole_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/cylinder.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_cylinder_thumb.png" height="190px"/>
+  </a>
+</p>
+
+## Otras recursos
+
+Es posible que esta biblioteca no satisfaga sus necesidades; si es así, considere echar un vistazo a estos otros recursos:
+
+- [meshwell](https://github.com/simbilod/meshwell) - Envoltorio para GMSH con enfoque en la óptica fotónica integrada.  
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) - Modelado orientado a objetos con Gmsh.  
+- [optimesh](https://github.com/meshpro/optimesh) - Optimización y suavizado de mallas.  
+- [pandamesh](https://github.com/Deltares/pandamesh) - Conversión de geodatos a mallas.  
+- [pygalmesh](https://github.com/meshpro/pygalmesh) - Interfaz en Python para las herramientas de malla de CGAL.  
+- [pygmsh](https://github.com/nschloe/pygmsh) - Gmsh para Python.  
+- [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) - Generación de mallas mediante PyVista.
+
+## Licencia
+
+[![Licencia: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+Este software se publica bajo la licencia [GPLv3](https://www.gnu.org/licenses/gpl-3.0.en.html).
+
+## Contribuciones
+
+Las contribuciones son _muy bienvenidas_.  
+Este proyecto se publica con un [Código de conducta para colaboradores](CODE_OF_CONDUCT.md).  
+Al participar en este proyecto, queremos que sepa que acepta cumplir con sus términos.
+
+## Historial de estrellas
+
+¿Le gusta scikit-gmsh? Demuestre su apoyo dando una [estrella en GitHub](https://github.com/pyvista/scikit-gmsh): es un simple clic que significa mucho para nosotros y también ayuda a otros a descubrirlo.
+
+[![Gráfico de historial de estrellas](https://api.star-history.com/svg?repos=pyvista/scikit-gmsh&type=Date)](https://star-history.com/#pyvista/scikit-gmsh&Date)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,84 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | [中文](./README_zh-CN.md) | **日本語** | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+<h1 align="center">
+  <a href="https://github.com/pyvista/scikit-gmsh#--------">
+    <img src="https://raw.githubusercontent.com/pyvista/scikit-gmsh/main/docs/_static/logo.svg"
+         alt="scikit-gmsh"
+         width="200"></a>
+</h1>
+
+3次元有限要素メッシュを生成するためのGmsh向けScikit。
+
+[![Status](https://badgen.net/badge/status/alpha/d8624d)](https://badgen.net/badge/status/alpha/d8624d)
+[![All Contributors](https://img.shields.io/github/all-contributors/pyvista/scikit-gmsh?color=ee8449)](https://scikit-gmsh.readthedocs.io/en/latest/reference/about.html#contributors)
+[![Contributing](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg)](https://github.com/pyvista/scikit-gmsh/issues)
+[![Documentation Status](https://readthedocs.org/projects/scikit-gmsh/badge/?version=latest)](https://scikit-gmsh.readthedocs.io/en/latest/?badge=latest)
+[![GitHub Repo stars](https://img.shields.io/github/stars/pyvista/scikit-gmsh)](https://github.com/pyvista/scikit-gmsh/stargazers)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Scientific Python](https://img.shields.io/badge/SPEC-0-blue.svg)](https://scientific-python.org/specs/spec-0000/)
+
+`scikit-gmsh`パッケージは、以下の機能へのシンプルなインターフェースを提供します：
+
+- Christophe Geuzaine および Jean-François Remacle 氏による [Gmsh](https://pypi.org/project/gmsh/)
+
+このライブラリには以下の主な目的があります：
+
+1. [scipy.spatial.Delaunay class](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html)のように、メッシュ作成のための直感的でオブジェクト指向のAPIを提供する。
+1. [Scientific Pythonエコシステム](https://scientific-python.org/)内の他のライブラリとシームレスに連携する。
+
+## インストール
+
+[![pypi](https://img.shields.io/pypi/v/scikit-gmsh?label=pypi&logo=python&logoColor=white)](https://pypi.org/project/scikit-gmsh/)
+
+```shell
+pip install scikit-gmsh
+```
+
+## ギャラリー
+
+こちらでテーマ別に整理されたサンプルギャラリーをご覧ください：
+
+<p align="center">
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/icosahedron.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_icosahedron_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/polygon_with_hole.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_polygon_with_hole_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/cylinder.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_cylinder_thumb.png" height="190px"/>
+  </a>
+</p>
+
+## その他のリソース
+
+このライブラリがご要望を満たさない場合は、他のリソースもご覧になることをお勧めします：
+
+- [meshwell](https://github.com/simbilod/meshwell) - フォトニクス機能を統合したGMSHラッパー。  
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) - オブジェクト指向のGmshモデリングツール。  
+- [optimesh](https://github.com/meshpro/optimesh) - メッシュの最適化および平滑化処理を行うツール。  
+- [pandamesh](https://github.com/Deltares/pandamesh) - 地理データフレームからメッシュへの変換ツール。  
+- [pygalmesh](https://github.com/meshpro/pygalmesh) - CGALのメッシュ生成ツールをPythonで利用するためのインターフェース。  
+- [pygmsh](https://github.com/nschloe/pygmsh) - Python向けのGmsh実装。  
+- [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) - PyVistaを利用したメッシュ生成ツール。
+
+## ライセンス
+
+[![ライセンス: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+このソフトウェアは、[GPLv3 ライセンス](https://www.gnu.org/licenses/gpl-3.0.en.html)の下で公開されています。
+
+## 貢献のお願い
+
+ご貢献を心より歓迎します。
+このプロジェクトは、【コントリビューター行動規範](CODE_OF_CONDUCT.md)に基づいて公開されています。
+本プロジェクトに参加することで、利用者はその規約に従うことに同意したものとみなされます。
+
+## スターの推移履歴
+
+scikit-gmshを気に入りましたか？[GitHubの星マーク](https://github.com/pyvista/scikit-gmsh)を押してご支援ください。これはたった一度のクリックですが、私たちにとって大変意味のあることであり、他の人々がこのツールを見つけるのにも役立ちます！
+
+[![Star History Chart](https://api.star-history.com/svg?repos=pyvista/scikit-gmsh&type=Date)](https://star-history.com/#pyvista/scikit-gmsh&Date)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,4 +1,5 @@
 <!-- hy-mt2-i18n:start -->
+
 [English](./README.md) | [中文](./README_zh-CN.md) | **日本語** | [Español](./README_es.md)
 <!-- hy-mt2-i18n:end -->
 
@@ -57,12 +58,12 @@ pip install scikit-gmsh
 
 このライブラリがご要望を満たさない場合は、他のリソースもご覧になることをお勧めします：
 
-- [meshwell](https://github.com/simbilod/meshwell) - フォトニクス機能を統合したGMSHラッパー。  
-- [objectgmsh](https://github.com/nemocrys/objectgmsh) - オブジェクト指向のGmshモデリングツール。  
-- [optimesh](https://github.com/meshpro/optimesh) - メッシュの最適化および平滑化処理を行うツール。  
-- [pandamesh](https://github.com/Deltares/pandamesh) - 地理データフレームからメッシュへの変換ツール。  
-- [pygalmesh](https://github.com/meshpro/pygalmesh) - CGALのメッシュ生成ツールをPythonで利用するためのインターフェース。  
-- [pygmsh](https://github.com/nschloe/pygmsh) - Python向けのGmsh実装。  
+- [meshwell](https://github.com/simbilod/meshwell) - フォトニクス機能を統合したGMSHラッパー。
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) - オブジェクト指向のGmshモデリングツール。
+- [optimesh](https://github.com/meshpro/optimesh) - メッシュの最適化および平滑化処理を行うツール。
+- [pandamesh](https://github.com/Deltares/pandamesh) - 地理データフレームからメッシュへの変換ツール。
+- [pygalmesh](https://github.com/meshpro/pygalmesh) - CGALのメッシュ生成ツールをPythonで利用するためのインターフェース。
+- [pygmsh](https://github.com/nschloe/pygmsh) - Python向けのGmsh実装。
 - [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) - PyVistaを利用したメッシュ生成ツール。
 
 ## ライセンス

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,4 +1,5 @@
 <!-- hy-mt2-i18n:start -->
+
 [English](./README.md) | **中文** | [日本語](./README_ja.md) | [Español](./README_es.md)
 <!-- hy-mt2-i18n:end -->
 
@@ -57,12 +58,12 @@ pip install scikit-gmsh
 
 该库可能无法满足您的需求，若是如此，建议您查看这些其他资源：
 
-- [meshwell](https://github.com/simbilod/meshwell) —— 集成光子学功能的 GMSH 封装工具。  
-- [objectgmsh](https://github.com/nemocrys/objectgmsh) —— 基于面向对象方式的 Gmsh 建模工具。  
-- [optimesh](https://github.com/meshpro/optimesh) —— 网格优化与网格平滑处理工具。  
-- [pandamesh](https://github.com/Deltares/pandamesh) —— 用于将地理数据框转换为网格的工具。  
-- [pygalmesh](https://github.com/meshpro/pygalmesh) —— CGAL 网格生成工具的 Python 接口。  
-- [pygmsh](https://github.com/nschloe/pygmsh) —— 专为 Python 设计的 Gmsh 工具。  
+- [meshwell](https://github.com/simbilod/meshwell) —— 集成光子学功能的 GMSH 封装工具。
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) —— 基于面向对象方式的 Gmsh 建模工具。
+- [optimesh](https://github.com/meshpro/optimesh) —— 网格优化与网格平滑处理工具。
+- [pandamesh](https://github.com/Deltares/pandamesh) —— 用于将地理数据框转换为网格的工具。
+- [pygalmesh](https://github.com/meshpro/pygalmesh) —— CGAL 网格生成工具的 Python 接口。
+- [pygmsh](https://github.com/nschloe/pygmsh) —— 专为 Python 设计的 Gmsh 工具。
 - [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) —— 基于 PyVista 的网格生成工具。
 
 ## 许可证

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,84 @@
+<!-- hy-mt2-i18n:start -->
+[English](./README.md) | **中文** | [日本語](./README_ja.md) | [Español](./README_es.md)
+<!-- hy-mt2-i18n:end -->
+
+<h1 align="center">
+  <a href="https://github.com/pyvista/scikit-gmsh#--------">
+    <img src="https://raw.githubusercontent.com/pyvista/scikit-gmsh/main/docs/_static/logo.svg"
+         alt="scikit-gmsh"
+         width="200"></a>
+</h1>
+
+用于通过 Gmsh 生成三维有限元网格的 Scikit 工具。
+
+[![状态](https://badgen.net/badge/status/alpha/d8624d)](https://badgen.net/badge/status/alpha/d8624d)
+[![所有贡献者](https://img.shields.io/github/all-contributors/pyvista/scikit-gmsh?color=ee8449)](https://scikit-gmsh.readthedocs.io/en/latest/reference/about.html#contributors)
+[![欢迎提交贡献](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg)](https://github.com/pyvista/scikit-gmsh/issues)
+[![文档状态](https://readthedocs.org/projects/scikit-gmsh/badge/?version=latest)](https://scikit-gmsh.readthedocs.io/en/latest/?badge=latest)
+[![GitHub 仓库星标数](https://img.shields.io/github/stars/pyvista/scikit-gmsh)](https://github.com/pyvista/scikit-gmsh/stargazers)
+[![许可证：GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![贡献者契约](https://img.shields.io/badge/contributor%20covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Scientific Python](https://img.shields.io/badge/SPEC-0-blue.svg)](https://scientific-python.org/specs/spec-0000/)
+
+`scikit-gmsh` 包提供了一个简洁的接口，用于：
+
+- Christophe Geuzaine 和 Jean-François Remacle 开发的 [Gmsh](https://pypi.org/project/gmsh/)
+
+该库的主要目标如下：
+
+1. 提供类似[scipy.spatial.Delaunay类](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.Delaunay.html)的直观、面向对象的网格创建API。
+1. 能够与[Scientific Python生态系统](https://scientific-python.org/)中的其他库实现无缝集成。
+
+## 安装
+
+[![pypi](https://img.shields.io/pypi/v/scikit-gmsh?label=pypi&logo=python&logoColor=white)](https://pypi.org/project/scikit-gmsh/)
+
+```shell
+pip install scikit-gmsh
+```
+
+## 示例集锦
+
+点击此处查看按主题分类的示例图集：
+
+<p align="center">
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/icosahedron.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_icosahedron_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/polygon_with_hole.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_polygon_with_hole_thumb.png" height="190px"/>
+  </a>
+  <a href="https://scikit-gmsh.readthedocs.io/en/latest/examples/cylinder.html">
+    <img src="https://scikit-gmsh.readthedocs.io/en/latest/_images/sphx_glr_cylinder_thumb.png" height="190px"/>
+  </a>
+</p>
+
+## 其他资源
+
+该库可能无法满足您的需求，若是如此，建议您查看这些其他资源：
+
+- [meshwell](https://github.com/simbilod/meshwell) —— 集成光子学功能的 GMSH 封装工具。  
+- [objectgmsh](https://github.com/nemocrys/objectgmsh) —— 基于面向对象方式的 Gmsh 建模工具。  
+- [optimesh](https://github.com/meshpro/optimesh) —— 网格优化与网格平滑处理工具。  
+- [pandamesh](https://github.com/Deltares/pandamesh) —— 用于将地理数据框转换为网格的工具。  
+- [pygalmesh](https://github.com/meshpro/pygalmesh) —— CGAL 网格生成工具的 Python 接口。  
+- [pygmsh](https://github.com/nschloe/pygmsh) —— 专为 Python 设计的 Gmsh 工具。  
+- [pyvista-gridder](https://github.com/INTERA-Inc/pyvista-gridder) —— 基于 PyVista 的网格生成工具。
+
+## 许可证
+
+[![许可证：GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+
+该软件依据[GPLv3许可证](https://www.gnu.org/licenses/gpl-3.0.en.html)发布。
+
+## 贡献指南
+
+我们_非常欢迎_您的贡献。
+本项目附带了一份[贡献者行为准则](CODE_OF_CONDUCT.md)。
+通过参与本项目，我们希望您知晓并同意遵守其中的条款。
+
+## 星标历史记录
+
+喜欢 scikit-gmsh 吗？请通过给它添加一个 [GitHub 星标](https://github.com/pyvista/scikit-gmsh)来表达您的支持——只需简单点击一下，这对我们意义重大，同时也有助于更多人发现它！
+
+[![星标数量变化图表](https://api.star-history.com/svg?repos=pyvista/scikit-gmsh&type=Date)](https://star-history.com/#pyvista/scikit-gmsh&Date)


### PR DESCRIPTION
## What this PR does

Adds README support for Simplified Chinese, Japanese, and Spanish so readers of those languages
can follow your project just as easily.

This is additive and opt-in: no existing content or code is changed, and the
new files are safe to close or delete at any time.

## Why we opened this PR

We're the team behind [Tencent Hunyuan MT (HY MT2)](https://github.com/Tencent-Hunyuan/Hy-MT2),
a translation model we recently open-sourced. We're using it to help open
source projects we appreciate reach readers in more languages.

We'd also love your feedback — both on the new READMEs in this PR and on the
[model](https://github.com/Tencent-Hunyuan/Hy-MT2#contact-us) itself.

## Scope of changes

**New README files (with language-switcher links)**

- README_zh-CN.md
- README_ja.md
- README_es.md

**Existing READMEs updated with language-switcher links only**

- README.md

That's the entire change: 4 files. Nothing else is touched.

> Worried about the upkeep? A separate companion PR can help keep these
> translations in sync automatically going forward — adopt it only if you
> want to.